### PR TITLE
BUGFIX: Edited Regex for getting page number

### DIFF
--- a/export.py
+++ b/export.py
@@ -44,7 +44,7 @@ def main():
 
     note_re = re.compile(r'\n'.join([
         r'(?P<title>.+)'
-        , r'((?P<type>Lesezeichen|Markierung|Notiz)[  ]+auf Seite[  ]+(?P<page>\d+): )'
+        , r'((?P<type>Lesezeichen|Markierung|Notiz)[  ]+auf Seite[  ]+(?P<page>.+): )'
         #note is optional
         + r'''((?P<note>(?:.|\n)*)
 )?''' + r'"(?P<quote>(?:.|\n)*)"'


### PR DESCRIPTION
Sometimes my Tolino Shine 3 does output following marked page number: "138-139"

"Markierung auf Seite "138-139":"
This produces an error. 

Now the issue is fixed :)
The regex can probably be better than mine :)
But this woked finde for me.